### PR TITLE
aa

### DIFF
--- a/.ipynb_checkpoints/Clasificador_EduCarrasco-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Clasificador_EduCarrasco-checkpoint.ipynb
@@ -76,7 +76,6 @@
    "source": [
     "import numpy as np\n",
     "import os\n",
-    "import re\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
     "from sklearn.model_selection import train_test_split\n",

--- a/Clasificador_EduCarrasco.ipynb
+++ b/Clasificador_EduCarrasco.ipynb
@@ -76,7 +76,6 @@
    "source": [
     "import numpy as np\n",
     "import os\n",
-    "import re\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
     "from sklearn.model_selection import train_test_split\n",


### PR DESCRIPTION
Tiene un par de cambios adicionales que considera sólo usar CV2 en vez de las librerías re y imghdr. Principalmente porque actualicé python y esas librerías estaban en vías de quedar obsoletas.

En la primera parte, están las condiciones de versión con las cuales corrí las librerías